### PR TITLE
HCT-6X missing AssemblyVariant

### DIFF
--- a/Flashpoint DLC Flashpoints/chassis/chassisdef_hatchetman_HCT-6X.json
+++ b/Flashpoint DLC Flashpoints/chassis/chassisdef_hatchetman_HCT-6X.json
@@ -1,4 +1,11 @@
 {
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Hatchetman",
+			"Exclude": false,
+			"Include": true
+		}
+	},
 	"ChassisTags": {
 		"items": [
 			"MediumMech"


### PR DESCRIPTION
added missing AssemblyVariant to chassisdef

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
