### PR TITLE
mackie prime fix

### DIFF
--- a/BT Advanced Mechs/chassis/chassisdef_mackie_MSK-PRIME.json
+++ b/BT Advanced Mechs/chassis/chassisdef_mackie_MSK-PRIME.json
@@ -229,7 +229,8 @@
 		"items": [
 			"ArmLimitUpperRight",
 			"ArmLimitLowerLeft",
-			"AssaultMech"
+			"AssaultMech",
+			"OmniMech"
 		],
 		"tagSetSourceFile": ""
 	},


### PR DESCRIPTION
added missing OmiMech tag to chassisdef

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
