### PR TITLE
Update for Internal Ammo items

### DIFF
--- a/BT Advanced Clan Gear/weapons/Weapon_SRM_SRM4_STREAK_CLAN_OS.json
+++ b/BT Advanced Clan Gear/weapons/Weapon_SRM_SRM4_STREAK_CLAN_OS.json
@@ -25,7 +25,7 @@
 		140,
 		210
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "OSSRM",
 	"StartingAmmoCapacity": 4,
 	"HeatGenerated": 12,
 	"Damage": 10,

--- a/BT Advanced Clan Gear/weapons/Weapon_SRM_SRM_NARC_CLAN_IOS.json
+++ b/BT Advanced Clan Gear/weapons/Weapon_SRM_SRM_NARC_CLAN_IOS.json
@@ -22,7 +22,7 @@
 		180,
 		270
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "OSNARC",
 	"StartingAmmoCapacity": 2,
 	"HeatGenerated": 0,
 	"Damage": 1,

--- a/BT Advanced Core/AmmoCategory.json
+++ b/BT Advanced Core/AmmoCategory.json
@@ -1902,7 +1902,7 @@
 			"UIColorRef": "QualityD",
 			"FallbackUIColor": "QualityD",
 			"Icon": "MissileHardpointIcon",
-			"OutOfAmmoAudioVOEvent": "AmmoDepleted_LRM"
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_AC20"
 		},
 		{
 			"ID": 6136,
@@ -1916,12 +1916,82 @@
 			"UIColorRef": "QualityD",
 			"FallbackUIColor": "QualityD",
 			"Icon": "MissileHardpointIcon",
-			"OutOfAmmoAudioVOEvent": "AmmoDepleted_LRM"
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_AC20"
 		},
 		{
 			"ID": 6137,
 			"Name": "ThumperCopperhead",
 			"FriendlyName": "ThumperCopperhead",
+			"IsBallistic": false,
+			"IsMissile": true,
+			"IsEnergy": false,
+			"IsSupport": false,
+			"UsesInternalAmmo": false,
+			"UIColorRef": "QualityD",
+			"FallbackUIColor": "QualityD",
+			"Icon": "MissileHardpointIcon",
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_AC10"
+		},
+		{
+			"ID": 6138,
+			"Name": "Cannonball",
+			"FriendlyName": "Cannonball",
+			"IsBallistic": false,
+			"IsMissile": true,
+			"IsEnergy": false,
+			"IsSupport": false,
+			"UsesInternalAmmo": false,
+			"UIColorRef": "QualityD",
+			"FallbackUIColor": "QualityD",
+			"Icon": "BallisticHardpointIcon",
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_AC20"
+		},
+		{
+			"ID": 6139,
+			"Name": "GyroJet",
+			"FriendlyName": "GyroJet",
+			"IsBallistic": false,
+			"IsMissile": true,
+			"IsEnergy": false,
+			"IsSupport": false,
+			"UsesInternalAmmo": false,
+			"UIColorRef": "QualityD",
+			"FallbackUIColor": "QualityD",
+			"Icon": "MissileHardpointIcon",
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_LRM"
+		},
+		{
+			"ID": 6140,
+			"Name": "OSNARC",
+			"FriendlyName": "OSNARC",
+			"IsBallistic": false,
+			"IsMissile": true,
+			"IsEnergy": false,
+			"IsSupport": false,
+			"UsesInternalAmmo": false,
+			"UIColorRef": "QualityD",
+			"FallbackUIColor": "QualityD",
+			"Icon": "MissileHardpointIcon",
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_LRM"
+		},
+		{
+			"ID": 6141,
+			"Name": "OSSRM",
+			"FriendlyName": "OSSRM",
+			"IsBallistic": false,
+			"IsMissile": true,
+			"IsEnergy": false,
+			"IsSupport": false,
+			"UsesInternalAmmo": false,
+			"UIColorRef": "QualityD",
+			"FallbackUIColor": "QualityD",
+			"Icon": "MissileHardpointIcon",
+			"OutOfAmmoAudioVOEvent": "AmmoDepleted_LRM"
+		},
+		{
+			"ID": 6142,
+			"Name": "OSLRM",
+			"FriendlyName": "OSLRM",
 			"IsBallistic": false,
 			"IsMissile": true,
 			"IsEnergy": false,

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_AC10_BOOMSTICK.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_AC10_BOOMSTICK.json
@@ -39,7 +39,7 @@
 		240,
 		360
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Cannonball",
 	"StartingAmmoCapacity": 10,
 	"HeatGenerated": 18,
 	"Damage": 90,

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_AC20_CANNONBALL.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_AC20_CANNONBALL.json
@@ -40,7 +40,7 @@
 		200,
 		300
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Cannonball",
 	"StartingAmmoCapacity": 10,
 	"HeatGenerated": 28,
 	"Damage": 120,

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_Heavy_Cannon.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_Heavy_Cannon.json
@@ -34,7 +34,7 @@
 		200,
 		300
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Cannonball",
 	"StartingAmmoCapacity": 1,
 	"HeatGenerated": 12,
 	"Damage": 300,

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_Light_Cannon.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_Light_Cannon.json
@@ -34,7 +34,7 @@
 		360,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Cannonball",
 	"StartingAmmoCapacity": 1,
 	"HeatGenerated": 15,
 	"Damage": 180,

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_Medium_Cannon.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_Medium_Cannon.json
@@ -34,7 +34,7 @@
 		280,
 		420
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Cannonball",
 	"StartingAmmoCapacity": 1,
 	"HeatGenerated": 6,
 	"Damage": 240,

--- a/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ10_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ10_0-STOCK.json
@@ -37,7 +37,7 @@
 		420,
 		630
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "GyroJet",
 	"StartingAmmoCapacity": 10,
 	"HeatGenerated": 10,
 	"Damage": 10,

--- a/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ15_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ15_0-STOCK.json
@@ -37,7 +37,7 @@
 		420,
 		630
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "GyroJet",
 	"StartingAmmoCapacity": 15,
 	"HeatGenerated": 15,
 	"Damage": 10,

--- a/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ20_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_Gyrojet_GJ20_0-STOCK.json
@@ -37,7 +37,7 @@
 		420,
 		630
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "GyroJet",
 	"StartingAmmoCapacity": 20,
 	"HeatGenerated": 20,
 	"Damage": 10,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 10,
 	"HeatGenerated": 10,
 	"Damage": 5,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_Inferno.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_Inferno.json
@@ -36,7 +36,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 10,
 	"HeatGenerated": 10,
 	"Damage": 2,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_Reload.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_Reload.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 20,
 	"HeatGenerated": 10,
 	"Damage": 4,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 15,
 	"HeatGenerated": 15,
 	"Damage": 5,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_Inferno.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_Inferno.json
@@ -36,7 +36,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 15,
 	"HeatGenerated": 15,
 	"Damage": 2,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_Reload.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_Reload.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 30,
 	"HeatGenerated": 15,
 	"Damage": 4,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 20,
 	"HeatGenerated": 20,
 	"Damage": 5,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_Inferno.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_Inferno.json
@@ -36,7 +36,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 20,
 	"HeatGenerated": 20,
 	"Damage": 2,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_Reload.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_Reload.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 40,
 	"HeatGenerated": 20,
 	"Damage": 4,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 40,
 	"HeatGenerated": 40,
 	"Damage": 5,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_Reload.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_Reload.json
@@ -34,7 +34,7 @@
 		330,
 		540
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "Rocket",
 	"StartingAmmoCapacity": 80,
 	"HeatGenerated": 40,
 	"Damage": 4,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SRM2_OS_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SRM2_OS_0-STOCK.json
@@ -21,7 +21,7 @@
 		180,
 		270
 	],
-	"AmmoCategory": "Flamer",
+	"AmmoCategory": "OSSRM",
 	"StartingAmmoCapacity": 2,
 	"HeatGenerated": 4,
 	"Damage": 8,
@@ -65,6 +65,73 @@
 	"DisallowedLocations": "All",
 	"CriticalComponent": false,
 	"statusEffects": [],
+	"Modes": [
+		{
+			"Id": "STD",
+			"UIName": "STD",
+			"isBaseMode": true
+		},
+		{
+			"Id": "TNDM",
+			"UIName": "Tandem",
+			"isBaseMode": false,
+			"Damage": -4,
+			"APDamage": 4,
+			"APCriticalChanceMultiplier": 0.015
+		},
+		{
+			"Id": "Inferno",
+			"UIName": "Inferno",
+			"isBaseMode": false,
+			"DamagePerShot": -4,
+			"statusEffects": [
+				{
+					"durationData": {
+						"duration": 2,
+						"ticksOnActivations": true,
+						"useActivationsOfTarget": true,
+						"ticksOnEndOfRound": false,
+						"ticksOnMovements": false,
+						"stackLimit": 1,
+						"clearedWhenAttacked": false
+					},
+					"targetingData": {
+						"effectTriggerType": "OnHit",
+						"triggerLimit": 0,
+						"extendDurationOnTrigger": 0,
+						"specialRules": "NotSet",
+						"effectTargetType": "NotSet",
+						"range": 0,
+						"forcePathRebuild": false,
+						"forceVisRebuild": false,
+						"showInTargetPreview": true,
+						"showInStatusPanel": true
+					},
+					"effectType": "StatisticEffect",
+					"Description": {
+						"Id": "Effect_InfernoSRMHeat",
+						"Name": "Inferno Gel",
+						"Details": "This unit is coated with burning chemicals, generating 6 extra heat each turn.",
+						"Icon": "fire-zone"
+					},
+					"statisticData": {
+						"statName": "HeatSinkCapacity",
+						"operation": "Int_Subtract",
+						"modValue": "6",
+						"modType": "System.Int32"
+					},
+					"nature": "Debuff"
+				}
+			]
+		},
+		{
+			"Id": "Coal",
+			"UIName": "Coal",
+			"isBaseMode": false,
+			"DamagePerShot": -4,
+			"Instability": 3
+		}
+	],
 	"ComponentTags": {
 		"items": [
 			"component_type_stock",

--- a/CustomAmmoCategories/ammunition/Ammunition_Cannonball.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_Cannonball.json
@@ -1,0 +1,20 @@
+{
+	"Description": {
+		"Id": "Ammunition_Cannonball",
+		"Name": "Cannonball Ammo",
+		"UIName": "Normal",
+		"Details": "Long range missiles, capable of dealing moderate damage at long range. Each missile lacks punch, but in a group they can deal significant damage.",
+		"Icon": null,
+		"Cost": 0,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"Type": "Normal",
+	"Category": "Cannonball",
+	"HeatGenerated": 0,
+	"HeatGeneratedModifier": 1,
+	"ArmorDamageModifier": 1,
+	"ISDamageModifier": 1,
+	"ClusteringModifier": 1.1,
+	"Unguided": true
+}

--- a/CustomAmmoCategories/ammunition/Ammunition_Gyrojet.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_Gyrojet.json
@@ -1,0 +1,20 @@
+{
+	"Description": {
+		"Id": "Ammunition_Gyrojet",
+		"Name": "Gyrojet Ammo",
+		"UIName": "Normal",
+		"Details": "Long range missiles, capable of dealing moderate damage at long range. Each missile lacks punch, but in a group they can deal significant damage.",
+		"Icon": null,
+		"Cost": 0,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"Type": "Normal",
+	"Category": "GyroJet",
+	"HeatGenerated": 0,
+	"HeatGeneratedModifier": 1,
+	"ArmorDamageModifier": 1,
+	"ISDamageModifier": 1,
+	"ClusteringModifier": 1.1,
+	"Unguided": true
+}

--- a/CustomAmmoCategories/ammunition/Ammunition_NARC_OS.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_NARC_OS.json
@@ -1,0 +1,20 @@
+{
+	"Description": {
+		"Id": "Ammunition_NARC_OS",
+		"Name": "OS NARC Ammo",
+		"UIName": "Normal",
+		"Details": "Long range missiles, capable of dealing moderate damage at long range. Each missile lacks punch, but in a group they can deal significant damage.",
+		"Icon": null,
+		"Cost": 0,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"Type": "Normal",
+	"Category": "OSNARC",
+	"HeatGenerated": 0,
+	"HeatGeneratedModifier": 1,
+	"ArmorDamageModifier": 1,
+	"ISDamageModifier": 1,
+	"ClusteringModifier": 1.1,
+	"Unguided": true
+}

--- a/CustomAmmoCategories/ammunition/Ammunition_Rocket.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_Rocket.json
@@ -1,0 +1,20 @@
+{
+	"Description": {
+		"Id": "Ammunition_Rocket",
+		"Name": "Rocket Ammo",
+		"UIName": "Normal",
+		"Details": "Long range missiles, capable of dealing moderate damage at long range. Each missile lacks punch, but in a group they can deal significant damage.",
+		"Icon": null,
+		"Cost": 0,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"Type": "Normal",
+	"Category": "Rocket",
+	"HeatGenerated": 0,
+	"HeatGeneratedModifier": 1,
+	"ArmorDamageModifier": 1,
+	"ISDamageModifier": 1,
+	"ClusteringModifier": 1.1,
+	"Unguided": true
+}

--- a/CustomAmmoCategories/ammunition/Ammunition_SRM_OS.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_SRM_OS.json
@@ -1,0 +1,20 @@
+{
+	"Description": {
+		"Id": "Ammunition_SRM_OS",
+		"Name": "OS SRM Ammo",
+		"UIName": "Normal",
+		"Details": "Long range missiles, capable of dealing moderate damage at long range. Each missile lacks punch, but in a group they can deal significant damage.",
+		"Icon": null,
+		"Cost": 0,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"Type": "Normal",
+	"Category": "OSSRM",
+	"HeatGenerated": 0,
+	"HeatGeneratedModifier": 1,
+	"ArmorDamageModifier": 1,
+	"ISDamageModifier": 1,
+	"ClusteringModifier": 1.1,
+	"Unguided": true
+}


### PR DESCRIPTION
1) Updated AmmoCategory.json to include new OneShot and Internal Ammo types, re-using existing types when possible  Converted Copperhead rounds to more appropriate AUTOCANNON type rather than MISSILE types.

2) Created new AmmoDefs for various new categories created <-required for this to work!

3) updated Rockets, Cannons, Gyrojets and OneShot missile launchers

3A) DID NOT TOUCH CC Nor were B or M Pods touched.

4) Updated One Shot SRMs to Mode-Switch between valid warhead types (Standard, Tandem, Inferno, and Coal).


