### PR TITLE
Gauss Cap fix

### DIFF
--- a/Community Content/upgrade/Gear_Gauss_Capacitor.json
+++ b/Community Content/upgrade/Gear_Gauss_Capacitor.json
@@ -7,9 +7,9 @@
 			"ExplosionDamage": 50
 		},
 		"BonusDescriptions": [
-				"GaussCapRange: +15%",
-				"GaussCapDmg: +15%",
-				"GaussCapHeat: +200%",
+				"GaussCapRange: +15",
+				"GaussCapDmg: +15",
+				"GaussCapHeat: +200",
 				"WeaponBoom: 50"
 			]
 	},


### PR DESCRIPTION
only needs percent signs in one place to avoid double percent signs, already present in BonusDescrtiption_MechEngineer

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
