### PR TITLE
Complete refactor

### DIFF
--- a/.github/workflows/wiki-merge.yml
+++ b/.github/workflows/wiki-merge.yml
@@ -12,13 +12,13 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Enable Cloudflare API workaround
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/toggleCloudflareApi.py enable
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/toggleCloudflareApi.py enable
     faction-update:
         needs: cloudflare-pass-enable
         name: Post Faction Info to Wiki
@@ -32,14 +32,14 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Faction automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/factionRenderer.py
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/factionRenderer.py
     factory-update:
         needs: cloudflare-pass-enable
         name: Post Factory Info to Wiki
@@ -53,14 +53,14 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Factory automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/factoryRenderer.py
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/factoryRenderer.py
     pilot-update:
         needs: cloudflare-pass-enable
         name: Post Pilot Info to Wiki
@@ -74,14 +74,14 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Pilot automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/pilotRenderer.py
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/pilotRenderer.py
     vehicle-update:
         needs: cloudflare-pass-enable
         name: Post Vehicle Info to Wiki
@@ -95,14 +95,14 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Run vehicle automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/vehicleRenderer.py
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/vehicleRenderer.py
     import-game-info-to-wiki:
         needs: cloudflare-pass-enable
         name: Uploading game info to wiki
@@ -119,8 +119,8 @@ jobs:
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
                 echo "Downloading importer"
-                TAG=$(curl -s https://api.github.com/repos/BattleTech-Advanced-3062/bta-wiki-import/releases/latest | jq -r '.tag_name')
-                wget https://github.com/BattleTech-Advanced-3062/bta-wiki-import/releases/download/${TAG}/bta-wiki-import_linux_amd64.tar.gz
+                TAG=$(curl -s https://api.github.com/repos/BattleTech-Advanced-3062-3062/bta-wiki-import/releases/latest | jq -r '.tag_name')
+                wget https://github.com/BattleTech-Advanced-3062-3062/bta-wiki-import/releases/download/${TAG}/bta-wiki-import_linux_amd64.tar.gz
                 tar xvf bta-wiki-import_linux_amd64.tar.gz
                 mkdir path-to-wikitext
                 ./bta-wiki-import export ./bta/ ./path-to-wikitext/
@@ -134,10 +134,10 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced/bta-wiki-automation'
+                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
                 path: wiki-gen
             - name: Disable Cloudflare API workaround
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
               run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/toggleCloudflareApi.py disable
+                python3 /home/runner/work/BattleTech-Advanced-3062/BattleTech-Advanced-3062/wiki-gen/src/toggleCloudflareApi.py disable

--- a/.github/workflows/wiki-merge.yml
+++ b/.github/workflows/wiki-merge.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Enable Cloudflare API workaround
               env:
@@ -32,7 +32,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Faction automation
               env:
@@ -53,7 +53,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Factory automation
               env:
@@ -74,7 +74,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Run Pilot automation
               env:
@@ -95,7 +95,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Run vehicle automation
               env:
@@ -134,7 +134,7 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'amidatelion/bta-wiki-automation'
+                repository: 'BattleTech-Advanced/bta-wiki-automation'
                 path: wiki-gen
             - name: Disable Cloudflare API workaround
               env:

--- a/.github/workflows/wiki-merge.yml
+++ b/.github/workflows/wiki-merge.yml
@@ -1,12 +1,27 @@
-name: Wiki Update Demo
-run-name: Pushing Updates to BTA Wiki
+name: Wiki Automation
+run-name: Updating the wiki
 on:
     push:
       branches:
         - wiki
 jobs:
-    post-to-wiki:
-        name: Post Updates to Wiki
+    cloudflare-pass-enable:
+        name: Enable Cloudflare Workaround
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out automation code
+              uses: actions/checkout@v4
+              with:
+                repository: 'amidatelion/bta-wiki-automation'
+                path: wiki-gen
+            - name: Enable Cloudflare API workaround
+              env:
+                CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+              run: |
+                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/toggleCloudflareApi.py enable
+    faction-update:
+        needs: cloudflare-pass-enable
+        name: Post Faction Info to Wiki
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository code
@@ -17,37 +32,110 @@ jobs:
             - name: Check out automation code
               uses: actions/checkout@v4
               with:
-                repository: 'BattleTech-Advanced-3062/bta-wiki-automation'
+                repository: 'amidatelion/bta-wiki-automation'
                 path: wiki-gen
-            - name: Enable Cloudflare API workaround
-              env:
-                CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-              run: |
-                python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/toggleCloudflareApi.py enable
             - name: Run Faction automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
                 python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/factionRenderer.py
+    factory-update:
+        needs: cloudflare-pass-enable
+        name: Post Factory Info to Wiki
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+              with:
+                repository: ${{ github.repository }}
+                path: bta
+            - name: Check out automation code
+              uses: actions/checkout@v4
+              with:
+                repository: 'amidatelion/bta-wiki-automation'
+                path: wiki-gen
             - name: Run Factory automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
                 python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/factoryRenderer.py
+    pilot-update:
+        needs: cloudflare-pass-enable
+        name: Post Pilot Info to Wiki
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+              with:
+                repository: ${{ github.repository }}
+                path: bta
+            - name: Check out automation code
+              uses: actions/checkout@v4
+              with:
+                repository: 'amidatelion/bta-wiki-automation'
+                path: wiki-gen
             - name: Run Pilot automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
                 python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/pilotRenderer.py
+    vehicle-update:
+        needs: cloudflare-pass-enable
+        name: Post Vehicle Info to Wiki
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+              with:
+                repository: ${{ github.repository }}
+                path: bta
+            - name: Check out automation code
+              uses: actions/checkout@v4
+              with:
+                repository: 'amidatelion/bta-wiki-automation'
+                path: wiki-gen
             - name: Run vehicle automation
               env:
                 WIKI_PASS: ${{ secrets.WIKI_PASS }}
                 WIKI_USER: ${{ secrets.WIKI_USER}}
               run: |
                 python3 /home/runner/work/BattleTech-Advanced/BattleTech-Advanced/wiki-gen/src/vehicleRenderer.py
+    import-game-info-to-wiki:
+        needs: cloudflare-pass-enable
+        name: Uploading game info to wiki
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+              with:
+                repository: ${{ github.repository }}
+                path: bta
+            - name: Export info
+              env:
+                WIKI_PASS: ${{ secrets.WIKI_PASS }}
+                WIKI_USER: ${{ secrets.WIKI_USER}}
+              run: |
+                echo "Downloading importer"
+                TAG=$(curl -s https://api.github.com/repos/BattleTech-Advanced-3062/bta-wiki-import/releases/latest | jq -r '.tag_name')
+                wget https://github.com/BattleTech-Advanced-3062/bta-wiki-import/releases/download/${TAG}/bta-wiki-import_linux_amd64.tar.gz
+                tar xvf bta-wiki-import_linux_amd64.tar.gz
+                mkdir path-to-wikitext
+                ./bta-wiki-import export ./bta/ ./path-to-wikitext/
+                ./bta-wiki-import import  -l https://www.bta3062.com/api.php  ./path-to-wikitext/
+    cloudflare-pass-disable:
+        if: ${{ always() }}
+        needs: [faction-update, factory-update, pilot-update, vehicle-update, import-game-info-to-wiki]
+        name: Disable Cloudflare Workaround
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out automation code
+              uses: actions/checkout@v4
+              with:
+                repository: 'amidatelion/bta-wiki-automation'
+                path: wiki-gen
             - name: Disable Cloudflare API workaround
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
This PR does 2 things:

1. Adds the wiki import process since we've confirmed it is blazingly fast now.  
2. Refactors the update code so that a failure on a given component does not stop others from running, while safely disabling the API workaround at the end.  

Example: https://github.com/amidatelion/bta-wiki-testing/actions/runs/16856106650

You'll note that the workflow shows as failed because various processes *did* fail, but:

1. Those that would be successful ran successfully.
2. The final step disabled the workaround.  