### PR TITLE
Tournament of Champions

### DIFF
--- a/Flashpoint DLC Flashpoints/flashpoints/fp_shadowOrg.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_shadowOrg.json
@@ -5,7 +5,7 @@
 		"Details": "Branch B has the extra encounter",
 		"Icon": ""
 	},
-	"Weight": 10,
+	"Weight": 200,
 	"InternalName": "shadowOrg",
 	"PublishState": "PUBLISHED",
 	"Difficulty": 6,

--- a/Urban Warfare Flashpoints/flashpoints/fp_tournament.json
+++ b/Urban Warfare Flashpoints/flashpoints/fp_tournament.json
@@ -5,7 +5,7 @@
 		"Details": "lorem ipsum",
 		"Icon": "uixTxrSpot_Flashpoint.png"
 	},
-	"Weight": 10,
+	"Weight": 200,
 	"InternalName": "tournament",
 	"PublishState": "PUBLISHED",
 	"Difficulty": 4,
@@ -14,7 +14,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_zhaomaon(cluff'sstand3130+)"
+				"planet_name_cluffsstand"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Urban Warfare Flashpoints/flashpoints/fp_yangBigScore.json
+++ b/Urban Warfare Flashpoints/flashpoints/fp_yangBigScore.json
@@ -5,7 +5,7 @@
 		"Details": "Short Split Template",
 		"Icon": "uixTxrSpot_flashpointContract2.png"
 	},
-	"Weight": 10,
+	"Weight": 200,
 	"InternalName": "yangBigScore",
 	"PublishState": "PUBLISHED",
 	"Difficulty": 5,


### PR DESCRIPTION
1. Urbie Tourney now will actually spawn. 
2. Set all BTA-touched flashpoints to have the same spawn chance  weight (200) 

Can revert the chance for Big Score and Shadow Org if desired.