### PR TITLE
missing duel ambush fix

### DIFF
--- a/ConcreteJungle/mod.json
+++ b/ConcreteJungle/mod.json
@@ -57,7 +57,6 @@
 				"DuoDuel_MaxRevenge1",
 				"DuoDuel_DoubleTrouble",
 				"DuoDuel_FestiveCouple",
-				"SoloDuel_TripleFChallenge",
 				"SoloDuel_AllEyesOn",
 				"SoloDuel_ATasteForWar",
 				"SoloDuel_ChallengeAccepted",


### PR DESCRIPTION
added missing gameworld duels to CJ blacklist

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
