### PR TITLE
Morningstars should not be perma-visible

### DIFF
--- a/VIPAdvanced/heavychassis/vehiclechassisdef_MORNINGSTAR.json
+++ b/VIPAdvanced/heavychassis/vehiclechassisdef_MORNINGSTAR.json
@@ -35,7 +35,7 @@
     "SpotterDistanceMultiplier": 1,
     "VisibilityMultiplier": 1,
     "SensorRangeMultiplier": 1,
-    "Signature": 1,
+    "Signature": 0,
     "Radius": 4,
     "LOSSourcePositions": [
         {

--- a/VIPAdvanced/heavychassis/vehiclechassisdef_MORNINGSTAR_CCV.json
+++ b/VIPAdvanced/heavychassis/vehiclechassisdef_MORNINGSTAR_CCV.json
@@ -35,7 +35,7 @@
     "SpotterDistanceMultiplier": 1,
     "VisibilityMultiplier": 1,
     "SensorRangeMultiplier": 1,
-    "Signature": 1,
+    "Signature": 0,
     "Radius": 4,
     "LOSSourcePositions": [
         {


### PR DESCRIPTION
The Morningstar can be targeted by the AI from anywhere on the map, because it has a Signature 1 instead of the standard zero.
