### PR TITLE
Sanctuary Emperor affinity fix

### DIFF
--- a/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5B.json
+++ b/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5B.json
@@ -1,4 +1,11 @@
 {
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Emperor",
+			"Exclude": false,
+			"Include": true
+		}
+	},
 	"Description": {
 		"Cost": 14000000,
 		"Rarity": 4,

--- a/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5D.json
+++ b/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5D.json
@@ -1,4 +1,11 @@
 {
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Emperor",
+			"Exclude": false,
+			"Include": true
+		}
+	},
 	"Description": {
 		"Cost": 14000000,
 		"Rarity": 4,

--- a/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5F.json
+++ b/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5F.json
@@ -1,4 +1,11 @@
 {
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Emperor",
+			"Exclude": false,
+			"Include": true
+		}
+	},
 	"Description": {
 		"Cost": 14000000,
 		"Rarity": 4,

--- a/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5G.json
+++ b/BT Advanced Sanctuary Worlds Mechs/chassis/chassisdef_emperor_EMP-5G.json
@@ -1,4 +1,11 @@
 {
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Emperor",
+			"Exclude": false,
+			"Include": true
+		}
+	},
 	"Description": {
 		"Cost": 14000000,
 		"Rarity": 4,


### PR DESCRIPTION
added AssemblyVariant to the Sanctuary Emperor variants so they get the Sturdy affinity and can be assembled with the other emperors

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
