### PR TITLE
Adding DID contracts to ManualDeployForbidContractTypes list

### DIFF
--- a/CustomUnits/mod.json
+++ b/CustomUnits/mod.json
@@ -307,7 +307,8 @@
 			"Blackout",
 			"SoloDuel",
 			"DuoDuel",
-			"BattleRoyale"
+			"BattleRoyale",
+			"DefenceInDepth"
 		],
 		"ConvoyMaxDistFromOther": 900,
 		"ConvoyMaxDistFromPlayer": 400,


### PR DESCRIPTION
Blacklisted DID contracts from manual deployment to avoid a lockup issue if users have enabled manual deployment

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
