### PR TITLE
Typo in Aether's old ability and the vehicle targeting computer.

### DIFF
--- a/Abilifier/abilities/AbilityDefBlueAP.json
+++ b/Abilifier/abilities/AbilityDefBlueAP.json
@@ -56,7 +56,7 @@
 				"Icon": "digital-trace"
 			},
 			"statisticData": {
-				"statName": "CriticalChanceMultipler",
+				"statName": "CriticalChanceMultiplier",
 				"operation": "Float_Add",
 				"modValue": "-0.5",
 				"modType": "System.Single",

--- a/VIPAdvanced/carquirks/Gear_Vehicle_TargetingComputer.json
+++ b/VIPAdvanced/carquirks/Gear_Vehicle_TargetingComputer.json
@@ -129,7 +129,7 @@
 			},
 			"nature": "Buff",
 			"statisticData": {
-				"statName": "CriticalChanceMultipler",
+				"statName": "CriticalChanceMultiplier",
 				"operation": "Float_Multiply",
 				"modValue": "1.15",
 				"modType": "System.Single",


### PR DESCRIPTION
both files have "CriticalChanceMultipler" instead of "CriticalChanceMultiplier"

Neither is currently used in BTA AFAIK but there's no reason to leave the code wrong in case either of them ever gets used in the future.
