### PR TITLE
hellhound fix

### DIFF
--- a/BT Advanced Clan Mechs/chassis/chassisdef_hellhound_HLH-6.json
+++ b/BT Advanced Clan Mechs/chassis/chassisdef_hellhound_HLH-6.json
@@ -142,16 +142,16 @@
 			"Location": "LeftTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Missile"
+					"WeaponMountID": "Missile",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Missile"
+					"WeaponMountID": "Missile",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -173,16 +173,16 @@
 			"Location": "RightTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -195,12 +195,12 @@
 			"Location": "RightArm",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,

--- a/BT Advanced Clan Mechs/chassis/chassisdef_hellhound_HLH-7.json
+++ b/BT Advanced Clan Mechs/chassis/chassisdef_hellhound_HLH-7.json
@@ -133,12 +133,12 @@
 			"Location": "LeftArm",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -151,12 +151,12 @@
 			"Location": "LeftTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Missile"
+					"WeaponMountID": "Missile",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -178,16 +178,16 @@
 			"Location": "RightTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -200,12 +200,12 @@
 			"Location": "RightArm",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,

--- a/BT Advanced Unique Mechs/chassis/chassisdef_hellhound_HLH-TM.json
+++ b/BT Advanced Unique Mechs/chassis/chassisdef_hellhound_HLH-TM.json
@@ -143,16 +143,16 @@
 			"Location": "LeftTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Missile"
+					"WeaponMountID": "Missile",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Missile"
+					"WeaponMountID": "Missile",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -174,16 +174,16 @@
 			"Location": "RightTorso",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,
@@ -196,12 +196,12 @@
 			"Location": "RightArm",
 			"Hardpoints": [
 				{
-					"Omni": false,
-					"WeaponMountID": "Energy"
+					"WeaponMountID": "Energy",
+					"Omni": false
 				},
 				{
-					"Omni": false,
-					"WeaponMountID": "AntiPersonnel"
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,


### PR DESCRIPTION
moved Omni field to be consistent with the other mechs.  side note:  if Omni is true the field being above WeaponMountID will not make the mount an omni mount

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
