### PR TITLE
Updated contract weights of WZ, DID and OR to 1 from 3

### DIFF
--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_Elastic_Defense.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_Elastic_Defense.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 8,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_HoldTheGroundUntilYouCant.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_HoldTheGroundUntilYouCant.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 8,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_Last_Stand.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_Last_Stand.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_LeapfroggingIsTheWay.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_LeapfroggingIsTheWay.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_RememberThe.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_RememberThe.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_SongOfRoland.json
+++ b/MissionControl/overrides/contracts/defenceindepth/DefenceInDepth_SongOfRoland.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_AbandoningMission.json
+++ b/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_AbandoningMission.json
@@ -4,7 +4,7 @@
     "contractDisplayStyle": "BaseCampaignNormal",
     "difficulty": 8,
     "difficultyUIModifier": 0,
-    "weight": 3,
+    "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
     "representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_BeOurShield.json
+++ b/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_BeOurShield.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_BreakingWorse.json
+++ b/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_BreakingWorse.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_GoingDark.json
+++ b/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_GoingDark.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_PurginTheEvidence.json
+++ b/MissionControl/overrides/contracts/organizedretreat/OrganizedRetreat_PurginTheEvidence.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BackupDuty.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BackupDuty.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BeingAttacked.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BeingAttacked.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BugSwarm.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_BugSwarm.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 3,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_DefeatAsMany.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_DefeatAsMany.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 8,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_LookAtMe.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_LookAtMe.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 8,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_ReinforcementsForHire.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_ReinforcementsForHire.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 5,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,

--- a/MissionControl/overrides/contracts/warzone_v2/Warzonev2_Surprised.json
+++ b/MissionControl/overrides/contracts/warzone_v2/Warzonev2_Surprised.json
@@ -4,7 +4,7 @@
 	"contractDisplayStyle": "BaseCampaignNormal",
 	"difficulty": 2,
 	"difficultyUIModifier": 0,
-	"weight": 3,
+	"weight": 1,
 	"scope": "STANDARD",
 	"finalDifficulty": 0,
 	"representativeCastDefIDOverride": null,


### PR DESCRIPTION
All of contracts have weight of 1, sync'ing those contracts to be in-line with the others.

====

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
