### PR TITLE
Fixes Ferret Tank and JKR-8Hz description

### DIFF
--- a/BT Advanced Mechs/chassis/chassisdef_jackrabbit_JKR-8Hz.json
+++ b/BT Advanced Mechs/chassis/chassisdef_jackrabbit_JKR-8Hz.json
@@ -15,7 +15,7 @@
 		"UIName": "Jackrabbit",
 		"Id": "chassisdef_jackrabbit_JKR-8Hz",
 		"Name": "Jackrabbit",
-		"Details": "The Jackrabbit is often maligned as a 'bad mech.'  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some groups, specifically Pafftek Industries, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take the Pafftek Industries JKR-8WT 'Nuclear Shape carrier' and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive infantry Davey Crockett launcher and its ammunition.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating. ",
+		"Details": "The Jackrabbit is often maligned as a \"bad mech.\"  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some aftermarket production houses, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take one of those alternate designs and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive gear from the chassis.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating.",
 		"Icon": "uixTxrIcon_jackrabbit"
 	},
 	"MovementCapDefID": "movedef_commando_COM-2D",
@@ -208,7 +208,7 @@
 		"tagSetSourceFile": ""
 	},
 	"StockRole": "Light Artillery",
-	"YangsThoughts": "The Jackrabbit is often maligned as a 'bad mech.'  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some groups, specifically Pafftek Industries, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take the Pafftek Industries JKR-8WT 'Nuclear Shape carrier' and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive infantry Davey Crockett launcher and its ammunition.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating.",
+	"YangsThoughts": "The Jackrabbit is often maligned as a \"bad mech.\"  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some aftermarket production houses, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take one of those alternate designs and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive gear from the chassis.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating.",
 	"FixedEquipment": [
 		{
 			"MountedLocation": "CenterTorso",

--- a/BT Advanced Mechs/mech/mechdef_jackrabbit_JKR-8Hz.json
+++ b/BT Advanced Mechs/mech/mechdef_jackrabbit_JKR-8Hz.json
@@ -29,7 +29,7 @@
 			"NewBeltPirates",
 			"TortugaFusiliers",
 			"ShenSeTian",
-	"StrychnineSlavers",
+			"StrychnineSlavers",
 			"SantandersKillers",
 			"HookwormsHighwaymen",
 			"CalderonsCommandos",
@@ -74,12 +74,13 @@
 		"UIName": "Jackrabbit JKR-8Hz",
 		"Id": "mechdef_jackrabbit_JKR-8Hz",
 		"Name": "Jackrabbit",
-		"Details": "The Jackrabbit is often maligned as a 'bad mech.'  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some groups, specifically Pafftek Industries, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take the Pafftek Industries JKR-8WT 'Nuclear Shape carrier' and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive infantry Davey Crockett launcher and its ammunition.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating. ",
+		"Details": "The Jackrabbit is often maligned as a \"bad mech.\"  Truth be told, it isn't great.  But the same can be said for just about any 20-25 ton mech built with a standard fusion core.  Some aftermarket production houses, as well as the Word of Blake, have sought to upgrade/renew the Jackrabbit design.  We at Periphery Arms however, thought we would take one of those alternate designs and turn it into something specially for deployment to cash strapped periphery powers.   First we removed the horrendously expensive gear from the chassis.   In its place, a Howitzer/4 with 3 tons of ammo.  A Periphery TAG system and a medium binary laser round out the JKR-8Hz's weapon loadout.   Protection is provided by cheap and reliable Retro Light Plating.",
 		"Icon": "uixTxrIcon_jackrabbit"
 	},
 	"simGameMechPartCost": 250000,
 	"Version": 1,
-	"Locations": [{
+	"Locations": [
+		{
 			"DamageLevel": "Functional",
 			"Location": "Head",
 			"CurrentArmor": 45,
@@ -152,7 +153,8 @@
 			"AssignedRearArmor": -1
 		}
 	],
-	"inventory": [{
+	"inventory": [
+		{
 			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "emod_armorslots_lightplating",
 			"ComponentDefType": "Upgrade",

--- a/VIPAdvanced/carquirks/Gear_Vehicle_Hard_Target.json
+++ b/VIPAdvanced/carquirks/Gear_Vehicle_Hard_Target.json
@@ -32,7 +32,7 @@
 	"PrefabIdentifier": "",
 	"BattleValue": 0,
 	"InventorySize": 2,
-	"Tonnage": 100,
+	"Tonnage": 0,
 	"AllowedLocations": "All",
 	"DisallowedLocations": "All",
 	"CriticalComponent": false,


### PR DESCRIPTION
Ferret Tank was 145 tons for a 45 ton hover tank.  Found another CarQuirk with a 100 ton mass.  Made it zero.

The JKR-8Hz has always referenced items NOT in BTAU.  Specifically the Pafftek Industries submod JKR-8WT and its Infantry SRM Davy Crockett launcher.   I have made the description generic without taking the flavor of the text away.  This change is to eliminate information that could be confusing to a player who doesn't sub-mod.

