### PR TITLE
Various fixes: Scramble Defense and Split Defense

### DIFF
--- a/MissionControl/contractTypeBuilds/Scramble_DefendBase/common.jsonc
+++ b/MissionControl/contractTypeBuilds/Scramble_DefendBase/common.jsonc
@@ -700,7 +700,7 @@
 		},
 		{
 			"Name": "Trigger_Dialogue_If_Spawn_Target_Lance_01b",
-			"TriggerOn": "ObjectiveStatusConditional",
+			"TriggerOn": "OnObjectiveUpdated",
 			"Description": "",
 			"Conditionals": [
 				{
@@ -745,7 +745,7 @@
 		},
 		{
 			"Name": "Trigger_Dialogue_If_Spawn_Target_Lance_02",
-			"TriggerOn": "ObjectiveStatusConditional",
+			"TriggerOn": "OnObjectiveUpdated",
 			"Description": "",
 			"Conditionals": [
 				{
@@ -790,7 +790,7 @@
 		},
 		{
 			"Name": "Trigger_Dialogue_If_Spawn_Target_Lance_02b",
-			"TriggerOn": "ObjectiveStatusConditional",
+			"TriggerOn": "OnObjectiveUpdated",
 			"Description": "",
 			"Conditionals": [
 				{

--- a/MissionControl/contractTypeBuilds/Scramble_DefendBase/common.jsonc
+++ b/MissionControl/contractTypeBuilds/Scramble_DefendBase/common.jsonc
@@ -908,7 +908,7 @@
 			"Results": [
 				{
 					"Type": "Dialogue",
-					"DialogueGuid": "e8a5d081-6749-4167-98dc-05471014ed78",
+					"DialogueGuid": "4350fb06-958d-4d1e-8e46-9e886a2466f1",
 					"IsInterrupt": false
 				}
 			]

--- a/MissionControl/contractTypeBuilds/SplitDefense/common.jsonc
+++ b/MissionControl/contractTypeBuilds/SplitDefense/common.jsonc
@@ -1119,7 +1119,7 @@
 		},
 		{
 			"Name": "Trigger_Dialogue_If_Spawn_Target_Lance_05",
-			"TriggerOn": "ObjectiveStatusConditional",
+			"TriggerOn": "OnObjectiveUpdated",
 			"Description": "",
 			"Conditionals": [
 				{
@@ -1188,7 +1188,7 @@
 		},
 		{
 			"Name": "Trigger_Dialogue_If_Spawn_Target_Lance_06",
-			"TriggerOn": "ObjectiveStatusConditional",
+			"TriggerOn": "OnObjectiveUpdated",
 			"Description": "",
 			"Conditionals": [
 				{

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_FirebreakProtocol.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_FirebreakProtocol.json
@@ -1379,7 +1379,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1473,7 +1473,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_HammerandAnvil.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_HammerandAnvil.json
@@ -1445,7 +1445,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1538,7 +1538,9 @@
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [],
+					"items": [
+						"mc_no_extended_lance"
+					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_LastShipment.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_LastShipment.json
@@ -1352,7 +1352,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1446,7 +1446,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_Operation_TwinLifeline.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_Operation_TwinLifeline.json
@@ -1416,7 +1416,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1510,7 +1510,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_SilentThunderRelay.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_SilentThunderRelay.json
@@ -1480,7 +1480,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1574,7 +1574,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},

--- a/MissionControl/overrides/contracts/splitdefense/SplitDefense_TensionLine.json
+++ b/MissionControl/overrides/contracts/splitdefense/SplitDefense_TensionLine.json
@@ -1336,7 +1336,7 @@
 				},
 				"lanceExcludedTagSet": {
 					"items": [
-						"lance_type_gladiator"
+						"mc_no_extended_lance"
 					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
@@ -1429,7 +1429,9 @@
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [],
+					"items": [
+						"mc_no_extended_lance"
+					],
 					"tagSetSourceFile": "Tags/LanceTags"
 				},
 				"spawnEffectTags": {


### PR DESCRIPTION
Scramble Defense:
- fixed dialogue error, reported by Pappy.  Would fix confusion that triggers the "destroyed all opfor" dialogue instead of "destroyed all ally turrets"
- fixed incorrect TriggerOn values on a few triggers, reported by redbatz.  No issue (no errors); fix would be inline as documented in MC

Split Defense:
- fixed incorrect TriggerOn values on a few triggers, reported by redbatz.  No issue (no errors); fix would be inline as documented in MC
- fixed "fixed-number-of-employer-turrets" to be randomyl generated/chosen (from 4 to 2) per lance, reported by redbatz.  No issue; fix would lead to not generate errors in logging.


Thanks.

====
Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
